### PR TITLE
Indexer and first draft of combining crawl and index

### DIFF
--- a/distribution.js
+++ b/distribution.js
@@ -7,6 +7,18 @@ const args = require("yargs").argv;
 //fetch fun for crawler
 global.fetch = require("sync-fetch");
 
+// imports used by indexer (though they really slow down node creation, 
+// perhaps there's a better way to do it)
+const natural = require('natural');
+global.stemmer = natural.PorterStemmer;
+const fs = require('fs');
+global.stopwords = new Set(
+  fs.readFileSync('non-distribution/d/stopwords.txt', 'utf-8')
+    .split('\n')
+    .map((word) => word.trim())
+    .filter((word) => word.length > 0),
+);
+
 // Default configuration
 global.nodeConfig = global.nodeConfig || {
   ip: "127.0.0.1",

--- a/distribution/all/mr.js
+++ b/distribution/all/mr.js
@@ -50,7 +50,8 @@ function mr(config) {
     const mapReduceService = { map: mapper, reduce: reducer };
     const compactor = configuration.compact;
     const memWay = configuration.memory ? "mem" : "store";
-    const out = configuration.out;
+    const mapOut = configuration.mapOut;
+    const reduceOut = configuration.reduceOut;
     let rounds = configuration.rounds;
     currId++;
     const serviceName = "mr-" + currId;
@@ -68,7 +69,7 @@ function mr(config) {
           //ready to do map
           const remote = { service: "mr", method: "map" };
           global.distribution[context.gid].comm.send(
-            [serviceName, keys, context.gid, memWay],
+            [serviceName, keys, context.gid, mapOut, memWay],
             remote,
             (e, v) => {
               remote.method = "shuffle";
@@ -86,7 +87,7 @@ function mr(config) {
                   remote.method = "reduce";
                   const allKeyList = Array.from(allNewKeys);
                   global.distribution[context.gid].comm.send(
-                    [serviceName, allKeyList, context.gid, out, memWay],
+                    [serviceName, allKeyList, context.gid, reduceOut, memWay],
                     remote,
                     (e, v) => {
                       let resultList = [];
@@ -106,7 +107,7 @@ function mr(config) {
                             return cb(null, resultList);
                           } else {
                             rounds--;
-                            if (rounds === 0) {
+                            if (rounds === 0 || resultList.length === 0) {
                               return cb(null, resultList);
                             } else {
                               //next round

--- a/distribution/engine/crawler.js
+++ b/distribution/engine/crawler.js
@@ -2,11 +2,11 @@ let crawler = {};
 crawler.map = (key, _value) => {
   const pkgName = key;
   const pkgID = distribution.util.id.getID(pkgName);
-  console.log(`crawling: ${key}`);
   if (!global.visited) {
     global.visited = new Set();
   }
   if (global.visited.has(pkgName)) return [];
+  console.log(`crawling: ${key}`);
   global.visited.add(pkgName);
   const url = `https://registry.npmjs.org/${pkgName}`;
   let metadata;

--- a/distribution/engine/crawler.js
+++ b/distribution/engine/crawler.js
@@ -2,11 +2,11 @@ let crawler = {};
 crawler.map = (key, _value) => {
   const pkgName = key;
   const pkgID = distribution.util.id.getID(pkgName);
-  console.log(key);
+  console.log(`crawling: ${key}`);
   if (!global.visited) {
     global.visited = new Set();
   }
-  if (global.visited.has(pkgName)) return null;
+  if (global.visited.has(pkgName)) return [];
   global.visited.add(pkgName);
   const url = `https://registry.npmjs.org/${pkgName}`;
   let metadata;
@@ -14,7 +14,7 @@ crawler.map = (key, _value) => {
   try {
     metadata = global.fetch(url).json(); // JSON object
   } catch (e) {
-    return null;
+    return [];
   }
 
   // Delay (to be polite)
@@ -32,14 +32,9 @@ crawler.map = (key, _value) => {
     dependencies: latestMeta.dependencies || {},
   };
 
-  const textKey = `${pkgID}+metadata`;
-  distribution.all.store.put({ [pkgName]: extracted }, textKey, (e, _v) => {
-    if (e) return null;
-  });
-
   // Prepare list of new packages to crawl
   const deps = Object.keys(extracted.dependencies);
-  return { [pkgName]: deps };
+  return { output: { [pkgName]: deps}, forStoring: extracted };
 };
 
 crawler.reduce = (key, values) => {

--- a/distribution/engine/engine.js
+++ b/distribution/engine/engine.js
@@ -1,0 +1,125 @@
+const distribution = require('../../config.js');
+const id = distribution.util.id;
+const crawler = require("./crawler.js");
+const indexer = require("./indexer.js");
+
+/*
+    The local node will be the orchestrator.
+*/
+let localServer = null;
+
+const nodes = [];
+for (let i = 0; i < 10; i++) {
+  nodes.push({
+    ip: '127.0.0.1',
+    port: 7110 + i,
+  })
+}
+
+const groups = {
+  all: {},
+  index: {},
+  query: {},
+};
+
+// Could potentially use this list of packages with the highest number of 
+// dependencies: https://gist.github.com/anvaka/8e8fa57c7ee1350e3491
+const rootPackages = [
+  // package with medium number of dependencies (for simple testing)
+  "express", 
+  // packages with many dependencies (for stress testing)
+  "khoom",
+  "toyako",
+  // "mhy",
+  // "cncjs",
+];
+
+function startNodes(cb) {
+  let numResponses = 0;
+  function onSpawn(node, e, v) {
+    if (e) console.log("error spawning node", node, e);
+    if (++numResponses === nodes.length) cb();
+  }
+  for (const node of nodes) {
+    distribution.local.status.spawn(node, (e, v) => onSpawn(node, e, v));
+  }
+};
+
+function setupGroups(cb) {
+  // For now, put all nodes in all groups
+  nodes.push(global.nodeConfig);
+  for (const node of nodes) {
+    const sid = id.getSID(node);
+    for (const group of Object.values(groups)) {
+      group[sid] = node;
+    }
+  }
+  let numResponses = 0;
+  function onGroupAdd(gid, e, v) {
+    if (e) console.log("error setting up group", gid, e);
+    if (++numResponses === Object.keys(groups).length) cb();
+  }
+  for (const [gid, group] of Object.entries(groups)) {
+    const config = { gid: gid };
+    distribution.local.groups.put(config, group, (e1, v) => {
+      distribution[gid].groups.put(config, group, (e2, v) => {
+        onGroupAdd(gid, e1 || Object.keys(e2).length, v);
+      });
+    });
+  }
+}
+
+function setupCrawler(cb) {
+  let numResponses = 0;
+  function handleResponse(package, e, v) {
+    if (e) console.log(`error preparing ${package} for crawling`, e);
+    if (++numResponses === rootPackages.length) cb();
+  }
+  for (const pkgName of rootPackages) {
+    distribution.all.store.put("null", pkgName, (e, v) => handleResponse(pkgName, e, v));
+  }
+}
+
+function cleanUpNodes() {
+  let numResponses = 0;
+  function onStop(node, e, v) {
+    if (e) console.log("error stopping node", node, e);
+    if (++numResponses === nodes.length) localServer.close();
+  }
+  const remote = {service: 'status', method: 'stop'};
+  for (const node of nodes) {
+    const stopRemote = {...remote, node: node};
+    distribution.local.comm.send([], stopRemote, (e, v) => onStop(node, e, v));
+  }
+}
+
+function runEngine() {
+  console.log("\n\n\n------SETTING UP------\n\n\n");
+  distribution.node.start((server) => {
+    localServer = server;
+    startNodes(() => {
+      setupGroups(() => {
+        setupCrawler(() => {
+          console.log("\n\n\n------STARTING CRAWLING------\n\n\n");
+          const mrConfig = {
+            map: crawler.map,
+            reduce: crawler.reduce,
+            rounds: 4, // TODO: figure out best number of rounds or make mapreduce detect when its found all (or a sufficient amount) of packages
+            keys: rootPackages,
+            mapOut: "index",
+          };
+          // TODO: insert page rank calculations here
+          distribution.all.mr.exec(mrConfig, (e, v) => {
+            console.log("\n\n\n------STARTING INDEXING------\n\n\n");
+            indexer.performIndexing((e, v) => {
+              console.log("\n\n\n------SHUTTING DOWN NODES------\n\n\n");
+              cleanUpNodes();
+            });
+          })
+        });
+      });
+    });
+  });
+}
+
+runEngine();

--- a/distribution/engine/engine.js
+++ b/distribution/engine/engine.js
@@ -108,14 +108,14 @@ function runEngine() {
             keys: rootPackages,
             mapOut: "index",
           };
-          // TODO: insert page rank calculations here
           distribution.all.mr.exec(mrConfig, (e, v) => {
+            // TODO: insert page rank calculations here
             console.log("\n\n\n------STARTING INDEXING------\n\n\n");
             indexer.performIndexing((e, v) => {
               console.log("\n\n\n------SHUTTING DOWN NODES------\n\n\n");
               cleanUpNodes();
             });
-          })
+          });
         });
       });
     });

--- a/distribution/engine/indexer.js
+++ b/distribution/engine/indexer.js
@@ -56,17 +56,4 @@ indexer.reduce = function (nGram, results) {
   return output;
 }
 
-indexer.performIndexing = function (callback) {
-  callback = callback || function() {};
-  distribution.index.store.get(null, (e, v) => {
-    const mrConfig = {
-      map: indexer.map,
-      reduce: indexer.reduce,
-      keys: v,
-      reduceOut: "query",
-    }
-    distribution.index.mr.exec(mrConfig, callback);
-  });
-}
-
 module.exports = indexer;

--- a/distribution/engine/indexer.js
+++ b/distribution/engine/indexer.js
@@ -1,0 +1,72 @@
+const distribution = global.distribution;
+
+/* 
+  Currently, the crawler stores the package data in the all group.
+  Each stored values has this structure:
+  const extracted = {
+    name: metadata.name,
+    version: latestVersion,
+    description: metadata.description,
+    dependencies: latestMeta.dependencies || {},
+      each dependency package name is a key, with the value being version
+  };
+*/
+
+const indexer = {};
+
+indexer.map = function (packageName, packageData) {
+  const description = packageData.description;
+  console.log(`index mapper: ${packageName}`);
+  // 1) process text to extract words
+  const words = description.replace(/[^A-Za-z]/g, " ")
+                           .split(" ")
+                           .filter(word => word !== "")
+                           .map(word => word.toLowerCase())
+                           .filter(word => !global.stopwords.has(word))
+                           .map(word => global.stemmer.stem(word));
+
+  // 2) combine words into n-grams
+  const maxNGramSize = 3;
+  const nGrams = [packageName]; // include packageName
+  for (let i = 0; i < words.length; i++) {
+    let nGram = [];
+    for (let offset = 0; (offset < maxNGramSize) && (i + offset < words.length); offset++) {
+      nGram.push(words[i + offset]);
+      nGrams.push(nGram.sort().join(" "));
+      nGram = [...nGram];
+    }
+  }
+
+  // 3) Sum the counts of all n-grams
+  const output = [];
+  const nGramToCount = {};
+  for (const nGram of nGrams) {
+    nGramToCount[nGram] = (nGramToCount[nGram] || 0) + 1;
+  }
+  for (const [nGram, count] of Object.entries(nGramToCount)) {
+    output.push({[nGram]: {package: packageName, count: count}});
+  }
+  return output;
+}
+
+indexer.reduce = function (nGram, results) {
+  console.log(`index reducer: ${nGram}`);
+  const output = {};
+  output[nGram] = results.sort((a, b) => b.count - a.count);
+  return output;
+}
+
+indexer.performIndexing = function (callback) {
+  callback = callback || function() {};
+  distribution.index.store.get(null, (e, v) => {
+    const mrConfig = {
+      map: indexer.map,
+      reduce: indexer.reduce,
+      keys: v,
+      reduceOut: "query",
+    }
+    distribution.index.mr.exec(mrConfig, callback);
+  });
+}
+
+module.exports = indexer;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "license": "ISC",
   "dependencies": {
     "yargs": "^17.7.2",
-    "@brown-ds/distribution": "latest"
+    "@brown-ds/distribution": "latest",
+    "natural": "^6.10.4"
   },
   "report": {
     "hours": 50,

--- a/test/test-student/m6.indexer.test.js
+++ b/test/test-student/m6.indexer.test.js
@@ -1,0 +1,123 @@
+const distribution = require('../../config.js');
+const id = distribution.util.id;
+const indexGroup = {};
+const queryGroup = {};
+
+/*
+    The local node will be the orchestrator.
+*/
+let localServer = null;
+
+const n1 = {ip: '127.0.0.1', port: 7110};
+const n2 = {ip: '127.0.0.1', port: 7111};
+const n3 = {ip: '127.0.0.1', port: 7112};
+
+jest.setTimeout(3600000);
+
+test("M6: basic index test", (done) => {
+  const indexer = require("../../distribution/engine/indexer.js");
+
+  const dataset = [
+    { "packageA": { description: "single" }},
+    { "packageB": { description: "document scenario" } },
+    { "packageC": { description: "document scenario document scenario distributed" } },
+  ];
+
+  const expected = [
+    { packageA: [{package: "packageA", count: 1}] }, 
+    { packageB: [{package: "packageB", count: 1}] }, 
+    { packageC: [{package: "packageC", count: 1}] }, 
+    { singl: [{package: "packageA", count: 1}] }, 
+    { document: [{package: "packageC", count: 2}, {package: "packageB", count: 1}] }, 
+    { scenario: [{package: "packageC", count: 2}, {package: "packageB", count: 1}] }, 
+    { distribut: [{package: "packageC", count: 1}] }, 
+    { "document scenario": [{package: "packageC", count: 3}, {package: "packageB", count: 1}] },
+    { "distribut scenario": [{package: "packageC", count: 1}] },
+    { "document document scenario": [{package: "packageC", count: 1}] },
+    { "document scenario scenario": [{package: "packageC", count: 1}] },
+    { "distribut document scenario": [{package: "packageC", count: 1}] },
+  ];
+
+  const doMapReduce = (cb) => {
+    indexer.performIndexing((e, v) => {
+      try {
+        expect(v).toEqual(expect.arrayContaining(expected));
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
+  };
+
+  let cntr = 0;
+  // Send the dataset to the cluster
+  dataset.forEach((o) => {
+    const key = Object.keys(o)[0];
+    const value = o[key];
+    distribution.index.store.put(value, key, (e, v) => {
+      cntr++;
+      // Once the dataset is in place, run the map reduce
+      if (cntr === dataset.length) {
+        doMapReduce();
+      }
+    });
+  });
+});
+
+/*
+    This is the setup for the test scenario.
+    Do not modify the code below.
+*/
+
+beforeAll((done) => {
+  indexGroup[id.getSID(n1)] = n1;
+  indexGroup[id.getSID(n2)] = n2;
+  indexGroup[id.getSID(n3)] = n3;
+
+  queryGroup[id.getSID(n1)] = n1;
+  queryGroup[id.getSID(n2)] = n2;
+  queryGroup[id.getSID(n3)] = n3;
+
+  const startNodes = (cb) => {
+    distribution.local.status.spawn(n1, (e, v) => {
+      distribution.local.status.spawn(n2, (e, v) => {
+        distribution.local.status.spawn(n3, (e, v) => {
+          cb();
+        });
+      });
+    });
+  };
+
+  distribution.node.start((server) => {
+    localServer = server;
+
+    startNodes(() => {
+      const indexConfig = { gid: "index" };
+      distribution.local.groups.put(indexConfig, indexGroup, (e, v) => {
+        distribution.index.groups.put(indexConfig, indexGroup, (e, v) => {
+          const queryConfig = { gid: "query" };
+          distribution.local.groups.put(queryConfig, queryGroup, (e, v) => {
+            distribution.query.groups.put(queryConfig, queryGroup, (e, v) => {
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+});
+
+afterAll((done) => {
+  const remote = {service: 'status', method: 'stop'};
+  remote.node = n1;
+  distribution.local.comm.send([], remote, (e, v) => {
+    remote.node = n2;
+    distribution.local.comm.send([], remote, (e, v) => {
+      remote.node = n3;
+      distribution.local.comm.send([], remote, (e, v) => {
+        localServer.close();
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This code currently passes all tests, and I tested engine.sh on some decently large workloads (crawling packages with many dependencies and crawling over multiple rounds). 

This PR includes:
- code/tests for the indexer (Because of our conversation yesterday, I changed it so that the order of words within an n-gram doesn't matter)
- an engine.sh file that will run the crawler and then the indexer, leaving the data ready for a querier. 
- some changes to the map reduce files that include 
  - The "handleResponse" functions are meant to fix some bugs where an error would cause a node to either respond to a message twice or hang. "performShuffle" is also part of this -- it's not any new code, just the old code copy and pasted into a helper function.
  - allowing "out" to be used in both the mapping and reducing phase

Especially noteworthy things:
- The node spawning process is now slower because each node needs to download a copy of the stopwords. This is done in distribution.js (there might be a better way to do it). You might have to comment this out when running non-crawler/indexer tests.
- npm install will need to be run again because I added a package for the indexer.